### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,16 @@ from pathlib import Path
 
 from setuptools import setup
 
-requires = Path("requirements.txt").read_text().splitlines()
+requires = Path("requirements.txt")
 
-readme = Path("README.md").read_text()
+readme = Path("README.md")
 
 with Path("aiotnb/__init__.py").open("r") as f:
     version = re.search(r"^__version__ = \"([^\"]+)\"", f.read(), re.M).group(1)
 
 requires_optional = {
     "docs": [
-        "sphinx",
+        "sphinx",  # documentation
     ]
 }
 
@@ -27,10 +27,10 @@ setup(
     packages=[],
     license="MIT",
     description="A coroutine-based client for the TNB Network API",
-    long_description=readme,
+    long_description=readme.read_text().splitlines(),
     long_description_content_type="text/markdown",
     include_package_data=True,
-    install_requires=requires,
+    install_requires=requires.read_text().splitlines(),
     extras_require=requires_optional,
     python_requires=">=3.8.0",
     classifiers=[],


### PR DESCRIPTION
Use `readme` and `requires` contexts. Don’t store file content in memory. Not critical here, but in other cases could result in file contents left in memory outside of needed context.