### PR TITLE
Refactor local account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ aiotnb.sublime-project
 aiotnb.sublime-workspace
 proposals/
 pyrightconfig.json
+.vscode

--- a/aiotnb/core.py
+++ b/aiotnb/core.py
@@ -296,7 +296,7 @@ class LocalAccount:
             The signing_key was not valid.
         """
         try:
-            self._sign_key = SigningKey(signing_key, encoder=HexEncoder)
+            self._sign_key = SigningKey(signing_key.encode(), encoder=HexEncoder)
         except Exception as e:
             _log.error("signing key load failed")
             raise SigningKeyLoadFailed("key must be 32 bytes long and hex-encoded", original=e) from e
@@ -342,7 +342,7 @@ class LocalAccount:
             _log.error("keyfile path was not found")
             raise KeyfileNotFound(f"'{file_path.name}' was not found on the system")
 
-        return cls(raw_key)
+        return cls(raw_key.decode())
 
     @classmethod
     def generate(cls) -> LocalAccount:
@@ -350,7 +350,7 @@ class LocalAccount:
         Generates a new keypair and load an account from it.
         """
 
-        return cls(SigningKey.generate().encode(encoder=HexEncoder))
+        return cls(SigningKey.generate().encode(encoder=HexEncoder).decode())
 
     def write_key_file(self, key_file: Union[Path, str]):
         """
@@ -431,7 +431,7 @@ class LocalAccount:
             The verified message data
         """
         try:
-            verify_key = VerifyKey(account_number, encoder=HexEncoder)
+            verify_key = VerifyKey(account_number.encode(), encoder=HexEncoder)
         except Exception as e:
             _log.error("account number load failed")
             raise VerifyKeyLoadFailed("key must be 64 bytes long and hex-encoded", original=e) from e

--- a/tests/test_keypair.py
+++ b/tests/test_keypair.py
@@ -15,7 +15,7 @@ from aiotnb.core import LocalAccount, is_valid_keypair
 keypair_1 = LocalAccount.generate()
 keypair_2 = LocalAccount.generate()
 
-MESSAGE = b"THIS IS-A TEST[!@]"
+MESSAGE = "THIS IS-A TEST[!@]"
 stored_message = None
 
 
@@ -47,24 +47,9 @@ def test_write_raw(tmp_path):
     assert data == keypair_2.signing_key
 
 
-@pytest.mark.order(before="test_sign_load")
-def test_sign_store():
-    global stored_message
-
-    stored_message = keypair_1.sign_message(MESSAGE)
-
-    assert stored_message.message == HexEncoder.encode(MESSAGE)
-
-
-def test_sign_load():
-    message = keypair_2.verify(cast(SignedMessage, stored_message), keypair_1._verify_key)
-
-    assert message == MESSAGE
-
-
-@pytest.mark.order(after="test_sign_load")
-def test_sign_load_raw():
-    message = keypair_2.verify_raw(HexEncoder.encode(MESSAGE), stored_message.signature, keypair_1.account_number)
+def test_sign():
+    signature = keypair_2.sign_message(MESSAGE)
+    message = keypair_2.verify(MESSAGE, signature, keypair_2.account_number)
 
     assert message == MESSAGE
 

--- a/tests/test_keypair.py
+++ b/tests/test_keypair.py
@@ -49,7 +49,7 @@ def test_write_raw(tmp_path):
 
 def test_sign():
     signature = keypair_2.sign_message(MESSAGE)
-    message = keypair_2.verify(MESSAGE, signature, keypair_2.account_number)
+    message = keypair_2.verify(MESSAGE, signature, keypair_2.account_number.decode())
 
     assert message == MESSAGE
 


### PR DESCRIPTION
Refactored `LocalAccount` class. Changed all functions to accept str data typed instead of bytes or nacl types. 

This was done in order to ease the flow between the network and the SDK. Users can use the hex strings returned from the network directly instead of converting to and from byte values or nacl types.