### PR TITLE
Setup type annotations backport for Python 3.6.1+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import re
 from pathlib import Path
+from sys import version_info
 
 from setuptools import setup
 
@@ -15,6 +16,14 @@ with Path("aiotnb/__init__.py").open("r") as f:
 requires_optional = {
     "docs": ["sphinx>=3.5.4", "sphinxcontrib_trio>=1.1.2", "furo>=2021.4.11b34", "sphinx-copybutton>=0.3.1"]
 }
+
+# type annotation support for Python versions 3.6.1+
+is_py36 = (version_info.major, version_info.minor) == (3, 6)
+py36_compatible = is_py36 and (version_info.micro >= 1)
+if py36_compatible:
+    requires.append("future-annotations>=1.0.0")
+    # Non-standard environments (ex. AWS Lambda, iOS_Python/Stash)
+    # See: https://github.com/asottile/future-annotations#when-you-arent-using-normal-site-registration
 
 setup(
     name="aiotnb",
@@ -31,6 +40,6 @@ setup(
     include_package_data=True,
     install_requires=requires,
     extras_require=requires_optional,
-    python_requires=">=3.8.0",
+    python_requires=">=3.6.1",
     classifiers=[],
 )


### PR DESCRIPTION
Recreated targeting `bank-api` branch

Adds the logic to require [`future-annotations`](https://pypi.org/project/future-annotations) at install for Python versions >=3.6.1.

To answer previous questions, 3.6.1 is minimum allowed by `future-annotations`. To get the specifics I would refer to the packages documentation.